### PR TITLE
RS-10248: Make NAs show up in labels

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipU
 Type: Package
 Title: Utilities Used In flip Packages
-Version: 1.5.12
+Version: 1.5.13
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Utility functions used across multiple flip packages.

--- a/R/utilites.R
+++ b/R/utilites.R
@@ -226,6 +226,9 @@ TrimCharacterAndWhitespace <- function(x, characters)
 #' @export
 MakeUniqueNames <- function(names, suffix = " ", prefix = "")
 {
+    ind.na <- which(is.na(names))
+    if (length(ind.na) > 0)
+        names[ind.na] <- "NA"
     ind.dup <- which(duplicated(names))
     if (nchar(suffix) < 1)
         stop("'suffix' cannot be empty")

--- a/tests/testthat/test-utilities.R
+++ b/tests/testthat/test-utilities.R
@@ -49,6 +49,7 @@ test_that("Trim character and white space",
 test_that("MakeUniqueNames",
 {
     expect_equal(MakeUniqueNames(rep(letters[1:3], 1:3)), c("a", "b", "b ", "c", "c ", "c  "))
+    expect_equal(MakeUniqueNames(c("A", "B", "C", NA, "A")), c("A", "B", "C", "NA", "A "))
 })
 
 test_that("EscapeRegexSymbols",
@@ -104,7 +105,7 @@ test_that("DS-4211: Names attributes are removed and data frames are returned as
     num <- setNames(num, txt)
     fac <- setNames(fac, txt)
     txt <- setNames(txt, txt)
-    
+
     x <- TidyDataForRVariableSet(num)
     expect_null(attr(x, "names"))
     expect_true(is.vector(x))
@@ -116,7 +117,7 @@ test_that("DS-4211: Names attributes are removed and data frames are returned as
     x <- TidyDataForRVariableSet(txt)
     expect_null(attr(x, "names"))
     expect_true(is.character(x))
-    
+
     mat <- matrix(1:12, nrow = 4)
     rownames(mat) <- letters[1:4]
     colnames(mat) <- letters[1:3]


### PR DESCRIPTION
The bug that led to this fix occurred in PrepareData for scatterplot. There a few other cases where `MakeUniqueNames` is called, but in all of them, it seems unlikely that we want missing values in the labels to remain as `NA`. I considered changing the label to be 'undefined', but NAs in the data labels already get shown as "NA", so this at least will be consistent.