### PR TITLE
EH-767 Handle extra args in Stop to facilitate migration from stop

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -11,5 +11,5 @@ Imports:
     utils
 Suggests:
     testthat
-RoxygenNote: 7.2.3
+RoxygenNote: 7.3.2
 Encoding: UTF-8

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,7 +1,7 @@
 Package: flipU
 Type: Package
 Title: Utilities Used In flip Packages
-Version: 1.6.0
+Version: 1.6.1
 Author: Displayr <opensource@displayr.com>
 Maintainer: Displayr <opensource@displayr.com>
 Description: Utility functions used across multiple flip packages.

--- a/R/errors.R
+++ b/R/errors.R
@@ -14,10 +14,10 @@ CheckVariableLengths <- function(variable.list, list.name)
 }
 
 #' Error condition with special class to identify user errors
-#' @param x The message to pass to the user
-#' @param ... Additional arguments to pass to errorCondition
+#' @param ... The arguments to pass to errorCondition
 #' @return An errorCondition with the "UserError" class
 #' @export
-Stop <- function(x, ...) {
-    errorCondition(x, ..., class = "UserError") |> stop()
+Stop <- function(..., domain = NULL) {
+    message <- .makeMessage(..., domain = domain)
+    errorCondition(message, class = "UserError") |> stop()
 }

--- a/R/errors.R
+++ b/R/errors.R
@@ -14,10 +14,16 @@ CheckVariableLengths <- function(variable.list, list.name)
 }
 
 #' Error condition with special class to identify user errors
-#' @param ... The arguments to pass to errorCondition
-#' @return An errorCondition with the "UserError" class
+#' @param call. Unused parameter, used to absorb usage from previous calls using stop
+#' @inheritParams base::stop
 #' @export
-Stop <- function(..., domain = NULL) {
+Stop <- function(..., call. = FALSE, domain = NULL) {
+    # Using a custom error condition and throwing using `stop` assumes the message
+    # is already constructed from the custom error condition, so call. parameter is redundant
+    call.used <- match.call()[["call."]]
+    if (is.logical(call.used)) {
+        warning("call. argument not supported in Stop, the call is never part of the error message")
+    }
     message <- .makeMessage(..., domain = domain)
     errorCondition(message, class = "UserError") |> stop()
 }

--- a/man/Stop.Rd
+++ b/man/Stop.Rd
@@ -4,15 +4,17 @@
 \alias{Stop}
 \title{Error condition with special class to identify user errors}
 \usage{
-Stop(x, ...)
+Stop(..., call. = FALSE, domain = NULL)
 }
 \arguments{
-\item{x}{The message to pass to the user}
+\item{...}{zero or more objects which can be coerced to character
+    (and which are pasted together with no separator) or a single
+    condition object.}
 
-\item{...}{Additional arguments to pass to errorCondition}
-}
-\value{
-An errorCondition with the "userError" class
+\item{call.}{Unused parameter, used to absorb usage from previous calls using stop}
+
+\item{domain}{see \code{\link[base]{gettext}}.  If \code{NA}, messages will
+    not be translated.}
 }
 \description{
 Error condition with special class to identify user errors

--- a/tests/testthat/test-error.R
+++ b/tests/testthat/test-error.R
@@ -6,4 +6,13 @@ test_that("Errors are constructed correctly", {
     user.error |> inherits(what = "error") |> expect_true()
     user.error |> inherits(what = "condition") |> expect_true()
     user.error[["message"]] |> expect_equal("Incorrect selection")
+    # Ellipsis works as expected
+    user.error <- Stop("Incorrect selection ", "used over ", "the dots") |> capture_error()
+    user.error[["message"]] |> expect_equal("Incorrect selection used over the dots")
+    inherits(user.error, "UserError") |> expect_true()
+    foo <- function(x) {
+        Stop("Incorrect selection ", x, " used over ", "the dots")
+    }
+    foo.error <- foo(1) |> capture_error()
+    foo.error[["message"]] |> expect_equal("Incorrect selection 1 used over the dots")
 })

--- a/tests/testthat/test-error.R
+++ b/tests/testthat/test-error.R
@@ -13,6 +13,11 @@ test_that("Errors are constructed correctly", {
     foo <- function(x) {
         Stop("Incorrect selection ", x, " used over ", "the dots")
     }
-    foo.error <- foo(1) |> capture_error()
-    foo.error[["message"]] |> expect_equal("Incorrect selection 1 used over the dots")
+    dots.working <- foo(1) |> capture_error()
+    dots.working[["message"]] |> expect_equal("Incorrect selection 1 used over the dots")
+    # Warning if using call.
+    warning.option <- getOption("warn")
+    options(warn = 2L)
+    on.exit(options(warn = warning.option))
+    Stop("Incorrect selection", call. = FALSE) |> expect_error("call. argument not supported in Stop")
 })


### PR DESCRIPTION
The domain parameter (for translation) is supported. However the call. parameter is not and
no information is prepended to the message when Stop is used. i.e. Stop(...) should behave
like stop(..., call. = FALSE)
